### PR TITLE
Enable latest version of newrelic agent

### DIFF
--- a/package.js
+++ b/package.js
@@ -2,7 +2,7 @@ Package.describe({
   summary: "meteor sql bindings for server-side calls"
 });
 
-Npm.depends({ "newrelic": "1.0.1" });
+Npm.depends({ "newrelic": "1.x.x" });
 
 Package.on_use(function(api) {
   if (api.export) api.export('newrelic', 'server');	


### PR DESCRIPTION
Hey Andrei, I was wondering if you could enable this change, in order for the latest reasonable version of newrelic nodejs agent to be used.
